### PR TITLE
Fixing build, exporing build commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ project(STP)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 include(GenerateExportHeader)
 include(GNUInstallDirs)

--- a/scripts/deps/setup-minisat.sh
+++ b/scripts/deps/setup-minisat.sh
@@ -13,7 +13,7 @@ cd "${dep_dir}"
 git clone https://github.com/stp/minisat "${dep}"
 cd "${dep}"
 mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX:PATH="${install_dir}" ..
+cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX:PATH="${install_dir}" ..
 cmake --build . --parallel "$(nproc)"
 cmake --install .
 cd ..


### PR DESCRIPTION
Also, this patch needs to be applied to MiniSat before build (after clone):

```
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 465fd91..170aef8 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.6 FATAL_ERROR)

 project(minisat)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)

 #--------------------------------------------------------------------------------------------------
 # Configurable options:
```

As per email, otherwise build complains.